### PR TITLE
Limit recursion when parsing URL in document-blocked page.

### DIFF
--- a/src/js/main-blocked.js
+++ b/src/js/main-blocked.js
@@ -87,7 +87,9 @@ uDom('.what').text(details.url);
         return s;
     };
 
-    const renderParams = function(parentNode, rawURL) {
+    // https://github.com/geekprojects/nuTensor/issues/23
+    //   Limit recursion.
+    const renderParams = function(parentNode, rawURL, depth = 0) {
         const a = document.createElement('a');
         a.href = rawURL;
         if ( a.search.length === 0 ) { return false; }
@@ -109,9 +111,9 @@ uDom('.what').text(details.url);
             const name = safeDecodeURIComponent(param.slice(0, pos));
             const value = safeDecodeURIComponent(param.slice(pos + 1));
             const li = liFromParam(name, value);
-            if ( reURL.test(value) ) {
+            if ( depth < 2 && reURL.test(value) ) {
                 const ul = document.createElement('ul');
-                renderParams(ul, value);
+                renderParams(ul, value, depth + 1);
                 li.appendChild(ul);
             }
             parentNode.appendChild(li);


### PR DESCRIPTION
https://github.com/gorhill/uBlock/commit/b75921c2fd0a704e7c3fc35453aa6223c0c91442
https://github.com/geekprojects/nuTensor/issues/23
https://github.com/vtriolet/writings/blob/main/posts/2021/ublock_origin_and_umatrix_denial_of_service.adoc

Co-authored-by: Raymond Hill <rhill@raymondhill.net>

Tested with firefox-91.0b3 (developer).

Closes #23